### PR TITLE
Update popover.vue

### DIFF
--- a/src/popover.vue
+++ b/src/popover.vue
@@ -42,7 +42,7 @@
         this.$refs.popover.addEventListener('mouseleave', this.close)
       }
     },
-    destroyed () {
+    beforeDestroy () {
       if (this.trigger === 'click') {
         this.$refs.popover.removeEventListener('click', this.onClick)
       } else {


### PR DESCRIPTION
popover组件的destroy钩子修改为beforeDestroy。

解决销毁组件时报错的bug